### PR TITLE
Fixing permission edit + variable config

### DIFF
--- a/Form/AttributePermissionFormHandler.php
+++ b/Form/AttributePermissionFormHandler.php
@@ -12,6 +12,7 @@ namespace Sidus\EAVPermissionBundle\Form;
 
 use Sidus\EAVModelBundle\Form\AttributeFormBuilderInterface;
 use Sidus\EAVModelBundle\Model\AttributeInterface;
+use Sidus\EAVPermissionBundle\Security\Permission;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -56,12 +57,14 @@ class AttributePermissionFormHandler implements AttributeFormBuilderInterface
         AttributeInterface $attribute,
         array $options = []
     ): void {
-        // Not (Read OR edit)
-        if (!$this->authorizationChecker->isGranted(['read', 'edit'], $attribute)) {
+        // Not (Read OR edit OR create)
+        if (!$this->authorizationChecker->isGranted([Permission::READ, Permission::EDIT, Permission::CREATE], $attribute)) {
             return;
         }
-        if (!$this->authorizationChecker->isGranted('edit', $attribute)) {
-            $options['form_options']['disabled'] = true;
+        if (!$this->authorizationChecker->isGranted(Permission::EDIT, $attribute)) {
+            if ('form_referentiels_edit' === $builder->getName()) {
+                $options['form_options']['disabled'] = true;
+            }
         }
 
         $this->baseAttributeFormBuilder->addAttribute($builder, $attribute, $options);

--- a/Voter/AttributeVoter.php
+++ b/Voter/AttributeVoter.php
@@ -11,6 +11,7 @@
 namespace Sidus\EAVPermissionBundle\Voter;
 
 use Sidus\EAVModelBundle\Model\AttributeInterface;
+use Sidus\EAVPermissionBundle\Security\Permission;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
@@ -48,7 +49,7 @@ class AttributeVoter implements VoterInterface
         }
 
         foreach ($attributes as $attribute) {
-            if (!\in_array($attribute, ['edit', 'read'], true)) {
+            if (!\in_array($attribute, [Permission::EDIT, Permission::READ, Permission::CREATE], true)) {
                 throw new \UnexpectedValueException("Unsupported Attribute permission type {$attribute}");
             }
 


### PR DESCRIPTION
- Add permission "create" to test in AttributeVoter
- Change texts "create" "edit" "read" to Permission const
- Checking the context for the edit permission